### PR TITLE
Add Qodo to "Coding & App Builders" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**Tabnine**](https://www.tabnine.com/) – Privacy-focused code autocompletion.  
 - [**Warp Terminal**](https://www.warp.dev/) – AI-enhanced terminal wrapper for macOS with intelligent features (use defensively).
 - [**Kiro**](https://www.kiro.dev/) – Task-based AI IDE that brings structure to AI coding with spec-driven development.
+- [**Qodo**](https://www.qodo.ai/) – Agentic AI platform for code generation, testing and automated code review.
 
 ---
 


### PR DESCRIPTION
Name: Qodo
Category: Coding & App Builders
Short description: Agentic AI platform for code generation, testing and automated code review. Integrates with IDEs, CI and provides multi-agent workflows focused on code quality.

Proof of recent activity / source:
- Qodo homepage: https://www.qodo.ai/
- Recent blog announcing Qodo Gen CLI (June 25, 2025): https://www.qodo.ai/blog/introducing-qodo-gen-cli-build-run-and-automate-agents-anywhere-in-your-sdlc/
- Their newest blog "Top 3 OpenAI Codex Alternatives for Developer Teams in 2025" (August 15, 2025): https://www.qodo.ai/blog/openai-codex-alternatives/

This is a small README addition to include Qodo in the Coding & App Builders list. Thanks!